### PR TITLE
Feat(auth): Goggle SSO authentication Logic

### DIFF
--- a/user/.gitignore
+++ b/user/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+.env

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -25,6 +25,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'me.paulschwarz:spring-dotenv:3.0.0'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/user/src/main/java/com/ns/user/UserApplication.java
+++ b/user/src/main/java/com/ns/user/UserApplication.java
@@ -1,4 +1,4 @@
-package com.ns.user;
+ㅎpackage com.ns.user;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/user/src/main/java/com/ns/user/UserApplication.java
+++ b/user/src/main/java/com/ns/user/UserApplication.java
@@ -1,4 +1,4 @@
-ㅎpackage com.ns.user;
+package com.ns.user;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/user/src/main/java/com/ns/user/configs/SecurityConfig.java
+++ b/user/src/main/java/com/ns/user/configs/SecurityConfig.java
@@ -1,4 +1,44 @@
 package com.ns.user.configs;
 
+import com.ns.user.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CorsConfigurationSource corsConfigurationSource;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
+                .csrf(AbstractHttpConfigurer::disable)
+                // jwt 기반 세션 생성x
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authz -> authz
+                        .requestMatchers(
+                                "/api/v1/auth/google/**", // 로그인/회원가입/콜백
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable);
+
+        return http.build();
+    }
 }

--- a/user/src/main/java/com/ns/user/exception/AuthException.java
+++ b/user/src/main/java/com/ns/user/exception/AuthException.java
@@ -1,0 +1,20 @@
+package com.ns.user.exception;
+
+public class AuthException extends RuntimeException{
+    private final ExceptionStatus status;
+    /**
+     * @param status exception에 대한 정보에 대한 enum
+     */
+    public AuthException(ExceptionStatus status) {
+        this.status = status;
+    }
+
+    public ExceptionStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return status.getMessage();
+    }
+}

--- a/user/src/main/java/com/ns/user/exception/ExceptionStatus.java
+++ b/user/src/main/java/com/ns/user/exception/ExceptionStatus.java
@@ -13,10 +13,19 @@ public enum ExceptionStatus {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
 
     AUTH_INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 인증 제공자입니다."),
+
     AUTH_GOOGLE_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 Google 토큰입니다."),
     AUTH_GOOGLE_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 Google 토큰입니다."),
+
+    AUTH_GOOGLE_CODE_EXCHANGE_FAILED(HttpStatus.BAD_GATEWAY, "Google 인가 코드 교환에 실패했습니다."),
+    AUTH_GOOGLE_ID_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "Google ID Token이 유효하지 않습니다."),
+    AUTH_GOOGLE_ID_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "Google ID Token이 만료되었습니다."),
+    AUTH_GOOGLE_ID_TOKEN_PARSE_ERROR(HttpStatus.BAD_REQUEST, "Google ID Token 파싱 중 오류가 발생했습니다."),
+    AUTH_GOOGLE_JWKS_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "구글 공개키 서버와 통신할 수 없습니다."),
+
     AUTH_JWT_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT입니다."),
     AUTH_JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 JWT입니다."),
+
 
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증 정보가 없습니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
@@ -30,7 +39,7 @@ public enum ExceptionStatus {
     SQL_FILE_LOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"SQL 파일 로딩 실패."),
     GENERAL_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에서 알 수 없는 오류가 발생했습니다"),
     GENERAL_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "서버가 작동하지 않고 있습니다."),
-    GENERAL_GATEWAY_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "서버에서 타임아웃이 발생했습니다"),;
+    GENERAL_GATEWAY_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "서버에서 타임아웃이 발생했습니다");
 
     private final int statusCode;
     private final String message;

--- a/user/src/main/java/com/ns/user/jwt/CurrentUser.java
+++ b/user/src/main/java/com/ns/user/jwt/CurrentUser.java
@@ -1,0 +1,18 @@
+package com.ns.user.jwt;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * @param id   Google sub
+ */
+public record CurrentUser(String id, String email, String name, String role) {
+
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role));
+    }
+}

--- a/user/src/main/java/com/ns/user/jwt/JwtAuthenticationFilter.java
+++ b/user/src/main/java/com/ns/user/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package com.ns.user.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+
+            String userId = jwtTokenProvider.getUserId(token);
+            String email = jwtTokenProvider.getEmail(token);
+            String name = jwtTokenProvider.getName(token);
+            String role = jwtTokenProvider.getRole(token);
+
+            CurrentUser user = new CurrentUser(userId, email, name, role);
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+
+
+    }
+
+
+    // Bearer 헤더 사용
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearer) && bearer.startsWith("Bearer ")) {
+            return bearer.substring(7);
+        }
+        return null;
+    }
+}

--- a/user/src/main/java/com/ns/user/jwt/JwtTokenProvider.java
+++ b/user/src/main/java/com/ns/user/jwt/JwtTokenProvider.java
@@ -1,0 +1,126 @@
+package com.ns.user.jwt;
+
+import com.ns.user.exception.AuthException;
+import com.ns.user.exception.ExceptionStatus;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private final String secretKey;
+    private final long accessExpMinutes;
+    private final long refreshExpDays;
+
+    private SecretKey key;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.access-exp-minutes}") long accessExpMinutes,
+            @Value("${jwt.refresh-exp-days}") long refreshExpDays
+    ) {
+        this.secretKey = secretKey;
+        this.accessExpMinutes = accessExpMinutes;
+        this.refreshExpDays = refreshExpDays;
+    }
+
+    @PostConstruct
+    private void init() {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // Access Token 생성
+    public String generateAccessToken(String userId, String email, String name, String role) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + accessExpMinutes * 60 * 1000);
+
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("email", email);
+        claims.put("name", name);
+        claims.put("role", role);
+        claims.put("type", "access");
+
+        return Jwts.builder()
+                .setSubject(userId) // Google sub
+                .addClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, Jwts.SIG.HS256) // HMAC-SHA256 서명
+                .compact();
+    }
+
+    //  Refresh Token 생성
+    public String generateRefreshToken(String userId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + refreshExpDays * 24 * 60 * 60 * 1000);
+
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("type", "refresh");
+
+        return Jwts.builder()
+                .setSubject(userId) // Google sub
+                .addClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    // 토큰 유효성 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            throw new AuthException(ExceptionStatus.AUTH_JWT_EXPIRED);
+        } catch (IllegalArgumentException | JwtException e) {
+            throw new AuthException(ExceptionStatus.AUTH_JWT_INVALID);
+        } catch (SecurityException e) {
+            throw new AuthException(ExceptionStatus.UNAUTHORIZED); // 서명 오류 → 인증 불가
+        }
+    }
+
+    // Claims 추출
+    private Claims getClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    public String getUserId(String token) {
+        return getClaims(token).getSubject();
+    }
+
+    public String getEmail(String token) {
+        return getClaims(token).get("email", String.class);
+    }
+
+    public String getName(String token) {
+        return getClaims(token).get("name", String.class);
+    }
+
+    public String getRole(String token) {
+        return getClaims(token).get("role", String.class);
+    }
+
+    public boolean isAccessToken(String token) {
+        return "access".equals(getClaims(token).get("type", String.class));
+    }
+
+    public boolean isRefreshToken(String token) {
+        return "refresh".equals(getClaims(token).get("type", String.class));
+    }
+}

--- a/user/src/main/java/com/ns/user/oauth/GoogleIdTokenVerifier.java
+++ b/user/src/main/java/com/ns/user/oauth/GoogleIdTokenVerifier.java
@@ -1,0 +1,94 @@
+package com.ns.user.oauth;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.ns.user.exception.AuthException;
+import com.ns.user.exception.ExceptionStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.text.ParseException;
+import java.util.Date;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GoogleIdTokenVerifier {
+
+    @Value("${google.client.id}")
+    private String clientId;
+
+    @Value("${google.oauth.issuer}")
+    // id_token(JWT)의 iss claim이 진짜 구글이 발급한 건지 확인하는 기준
+    private String issuer;
+
+    @Value("${google.oauth.jwks-uri}")
+    // 구글의 RSA 공개키 -> id_token을 검증
+    private String jwksUri;
+
+
+    // Google ID Token 검증 및 사용자 정보 추출
+    public GoogleUserInfo verify(String idToken) {
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(idToken);
+
+            // iss(구글에서 발급한지 검증), aud(이 토큰이 우리 앱을 위한건지 검증)
+            String tokenIssuer = signedJWT.getJWTClaimsSet().getIssuer();
+            String tokenAudience = signedJWT.getJWTClaimsSet().getAudience().get(0);
+
+            if (!issuer.equals(tokenIssuer) || !clientId.equals(tokenAudience)) {
+                throw new AuthException(ExceptionStatus.AUTH_GOOGLE_TOKEN_INVALID);
+            }
+
+            // JWK 세트 가져오기 (구글 공개키)
+            JWKSet jwkSet = JWKSet.load(new URL(jwksUri));
+            // 서명 검증
+            JWK jwk = jwkSet.getKeyByKeyId(signedJWT.getHeader().getKeyID());
+
+            if (jwk == null) {
+                throw new AuthException(ExceptionStatus.AUTH_GOOGLE_TOKEN_INVALID);
+            }
+
+            // 공개키로 서명 검증
+            boolean valid = signedJWT.verify(new RSASSAVerifier(jwk.toRSAKey()));
+            if (!valid) {
+                throw new AuthException(ExceptionStatus.AUTH_GOOGLE_TOKEN_INVALID);
+            }
+
+            // 만료 검증
+            if (signedJWT.getJWTClaimsSet().getExpirationTime().before(new Date())) {
+                throw new AuthException(ExceptionStatus.AUTH_GOOGLE_TOKEN_EXPIRED);
+            }
+
+            // sub, email, name 추출
+            String sub = signedJWT.getJWTClaimsSet().getSubject();
+            String email = signedJWT.getJWTClaimsSet().getStringClaim("email");
+            String name = signedJWT.getJWTClaimsSet().getStringClaim("name");
+
+            return new GoogleUserInfo(sub, email, name);
+
+        } catch (ParseException | MalformedURLException | JOSEException e) {
+            log.error("ID Token 검증 실패", e);
+            throw new AuthException(ExceptionStatus.AUTH_GOOGLE_ID_TOKEN_PARSE_ERROR);
+        } catch (IOException e) {
+            throw new AuthException(ExceptionStatus.AUTH_GOOGLE_JWKS_UNAVAILABLE);
+        }
+    }
+
+    // 구글 사용자 정보 객체
+    public record GoogleUserInfo(
+            String sub,    // Google 고유 ID
+            String email,
+            String name
+    ) {}
+}
+

--- a/user/src/main/java/com/ns/user/oauth/GoogleOAuthClient.java
+++ b/user/src/main/java/com/ns/user/oauth/GoogleOAuthClient.java
@@ -8,6 +8,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.HashMap;
@@ -38,14 +40,15 @@ public class GoogleOAuthClient {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        Map<String, String> params = new HashMap<>();
-        params.put("code", code);
-        params.put("client_id", clientId);
-        params.put("client_secret", clientSecret);
-        params.put("redirect_uri", redirectUri);
-        params.put("grant_type", "authorization_code");
 
-        HttpEntity<Map<String, String>> request = new HttpEntity<>(params, headers);
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", code);
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", redirectUri);
+        params.add("grant_type", "authorization_code");
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
 
         ResponseEntity<GoogleTokenResponse> response = restTemplate.exchange(
                 tokenUri,

--- a/user/src/main/java/com/ns/user/oauth/GoogleOAuthClient.java
+++ b/user/src/main/java/com/ns/user/oauth/GoogleOAuthClient.java
@@ -1,0 +1,74 @@
+package com.ns.user.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ns.user.exception.AuthException;
+import com.ns.user.exception.ExceptionStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GoogleOAuthClient {
+
+    @Value("${google.client.id}")
+    private String clientId;
+
+    @Value("${google.client.secret}")
+    private String clientSecret;
+
+    @Value("${google.client.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${google.oauth.token-uri}")
+    // Google Token 발급 uri
+    private String tokenUri;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    // 인가 코드 -> google 토큰 교환
+    public GoogleTokenResponse getTokens(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        Map<String, String> params = new HashMap<>();
+        params.put("code", code);
+        params.put("client_id", clientId);
+        params.put("client_secret", clientSecret);
+        params.put("redirect_uri", redirectUri);
+        params.put("grant_type", "authorization_code");
+
+        HttpEntity<Map<String, String>> request = new HttpEntity<>(params, headers);
+
+        ResponseEntity<GoogleTokenResponse> response = restTemplate.exchange(
+                tokenUri,
+                HttpMethod.POST,
+                request,
+                GoogleTokenResponse.class
+        );
+
+        if (response.getStatusCode() != HttpStatus.OK || response.getBody() == null) {
+            throw new AuthException(ExceptionStatus.AUTH_GOOGLE_TOKEN_INVALID);
+        }
+
+        log.debug("구글 토큰 응답: {}", response.getBody());
+        return response.getBody();
+    }
+
+    // inner 형식으로 사용
+    public record GoogleTokenResponse(
+            @JsonProperty("access_token") String accessToken,
+            @JsonProperty("id_token") String idToken,
+            @JsonProperty("refresh_token") String refreshToken,
+            @JsonProperty("scope") String scope,
+            @JsonProperty("token_type") String tokenType,
+            @JsonProperty("expires_in") Long expiresIn
+    ) {}
+}

--- a/user/src/main/java/com/ns/user/user/controller/AuthController.java
+++ b/user/src/main/java/com/ns/user/user/controller/AuthController.java
@@ -1,0 +1,85 @@
+package com.ns.user.user.controller;
+
+import com.ns.user.response.GlobalResponseHandler;
+import com.ns.user.response.ResponseStatus;
+import com.ns.user.user.dto.request.GoogleLoginRequestDto;
+import com.ns.user.user.dto.request.RefreshTokenRequestDto;
+import com.ns.user.user.dto.response.AuthResponseDto;
+import com.ns.user.user.service.UserService;
+import com.ns.user.user.vo.AuthVo;
+import com.ns.user.user.vo.GoogleLoginVo;
+import com.ns.user.user.vo.RefreshTokenVo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final UserService userService;
+
+    @Value("${jwt.refresh-exp-days}")
+    private long refreshExpDays;
+
+    @PostMapping("/google/callback")
+    public ResponseEntity<GlobalResponseHandler<AuthResponseDto>> googleLogin(
+            @RequestBody GoogleLoginRequestDto request
+    ) {
+        AuthVo vo = userService.loginWithGoogle(GoogleLoginVo.of(request.getCode()));
+
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", vo.refreshToken())
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .sameSite("Strict")
+                .maxAge(refreshExpDays)
+                .build();
+
+        AuthResponseDto responseDto = new AuthResponseDto(vo.accessToken());
+
+        return GlobalResponseHandler.successWithCookie(
+                ResponseStatus.AUTH_LOGIN_SUCCESS,
+                responseDto,
+                refreshCookie
+        );
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<GlobalResponseHandler<AuthResponseDto>> refresh(
+            @CookieValue("refreshToken") String refreshToken,
+            @RequestBody RefreshTokenRequestDto request
+    ) {
+
+        AuthVo vo = userService.refreshAccessToken(RefreshTokenVo.of(
+                request.getUserId(),
+                refreshToken));
+
+        AuthResponseDto responseDto = new AuthResponseDto(vo.accessToken());
+
+        return GlobalResponseHandler.success(
+                ResponseStatus.AUTH_REFRESH_SUCCESS,
+                responseDto
+        );
+    }
+
+    @PostMapping("/logout/{userId}")
+    public ResponseEntity<GlobalResponseHandler<Void>> logout(@PathVariable String userId) {
+        userService.logout(userId);
+
+        ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(0)
+                .build();
+
+        return GlobalResponseHandler.successWithCookie(
+                ResponseStatus.AUTH_LOGOUT_SUCCESS,
+                deleteCookie
+        );
+    }
+}

--- a/user/src/main/java/com/ns/user/user/controller/AuthController.java
+++ b/user/src/main/java/com/ns/user/user/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.ns.user.user.controller;
 
+import com.ns.user.jwt.CurrentUser;
 import com.ns.user.response.GlobalResponseHandler;
 import com.ns.user.response.ResponseStatus;
 import com.ns.user.user.dto.request.GoogleLoginRequestDto;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -66,9 +68,10 @@ public class AuthController {
         );
     }
 
-    @PostMapping("/logout/{userId}")
-    public ResponseEntity<GlobalResponseHandler<Void>> logout(@PathVariable String userId) {
-        userService.logout(userId);
+    @PostMapping("/logout")
+    public ResponseEntity<GlobalResponseHandler<Void>> logout(
+            @AuthenticationPrincipal CurrentUser currentUser) {
+        userService.logout(currentUser.id());
 
         ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
                 .httpOnly(true)

--- a/user/src/main/java/com/ns/user/user/dto/request/GoogleLoginRequestDto.java
+++ b/user/src/main/java/com/ns/user/user/dto/request/GoogleLoginRequestDto.java
@@ -1,0 +1,12 @@
+package com.ns.user.user.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoogleLoginRequestDto {
+    private String code;
+}

--- a/user/src/main/java/com/ns/user/user/dto/request/RefreshTokenRequestDto.java
+++ b/user/src/main/java/com/ns/user/user/dto/request/RefreshTokenRequestDto.java
@@ -1,0 +1,12 @@
+package com.ns.user.user.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshTokenRequestDto {
+    private String userId;
+}

--- a/user/src/main/java/com/ns/user/user/dto/response/AuthResponseDto.java
+++ b/user/src/main/java/com/ns/user/user/dto/response/AuthResponseDto.java
@@ -1,0 +1,13 @@
+package com.ns.user.user.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthResponseDto {
+    private String accessToken;
+}

--- a/user/src/main/java/com/ns/user/user/entity/UserEntity.java
+++ b/user/src/main/java/com/ns/user/user/entity/UserEntity.java
@@ -17,7 +17,6 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 public class UserEntity{
-
     @Id
     private String id; // Google sub (유일 식별자)
 

--- a/user/src/main/java/com/ns/user/user/repository/UserRepository.java
+++ b/user/src/main/java/com/ns/user/user/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.ns.user.user.repository;
+
+import com.ns.user.user.entity.UserEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface UserRepository extends MongoRepository<UserEntity,String> {
+    // id == Google sub
+}

--- a/user/src/main/java/com/ns/user/user/service/UserService.java
+++ b/user/src/main/java/com/ns/user/user/service/UserService.java
@@ -70,7 +70,7 @@ public class UserService {
         String role = jwtProvider.getRole(refreshVo.refreshToken());
 
         String newAccessToken = jwtProvider.generateAccessToken(refreshVo.userId(), email, name, role);
-        return new AuthVo(newAccessToken, refreshVo.refreshToken());
+        return new AuthVo(newAccessToken, null);
     }
 
     public void logout(String userId) {

--- a/user/src/main/java/com/ns/user/user/service/UserService.java
+++ b/user/src/main/java/com/ns/user/user/service/UserService.java
@@ -1,0 +1,79 @@
+package com.ns.user.user.service;
+
+import com.ns.user.exception.ExceptionStatus;
+import com.ns.user.exception.ServiceException;
+import com.ns.user.jwt.JwtTokenProvider;
+import com.ns.user.oauth.GoogleIdTokenVerifier;
+import com.ns.user.oauth.GoogleOAuthClient;
+import com.ns.user.user.entity.UserEntity;
+import com.ns.user.user.repository.UserRepository;
+import com.ns.user.user.vo.AuthVo;
+import com.ns.user.user.vo.GoogleLoginVo;
+import com.ns.user.user.vo.RefreshTokenVo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final GoogleOAuthClient googleOAuthClient;
+    private final GoogleIdTokenVerifier googleIdTokenVerifier;
+    private final JwtTokenProvider jwtProvider;
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${jwt.refresh-exp-days}")
+    private long refreshExpDays;
+
+    private static final String REFRESH_PREFIX = "refresh:";
+
+    public AuthVo loginWithGoogle(GoogleLoginVo loginVo) {
+        GoogleOAuthClient.GoogleTokenResponse tokenResponse = googleOAuthClient.getTokens(loginVo.code());
+        GoogleIdTokenVerifier.GoogleUserInfo userInfo = googleIdTokenVerifier.verify(tokenResponse.idToken());
+
+        // 사용자 조회시 존재하지 않는 회원이면 회원가입
+        UserEntity user = userRepository.findById(userInfo.sub())
+                .orElseGet(() -> userRepository.save(UserEntity.builder()
+                        .id(userInfo.sub())
+                        .email(userInfo.email())
+                        .name(userInfo.name())
+                        .role("USER")
+                        .oauthProvider("GOOGLE")
+                        .build()));
+
+        String accessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail(), user.getName(), user.getRole());
+        String refreshToken = jwtProvider.generateRefreshToken(user.getId());
+
+        redisTemplate.opsForValue().set(REFRESH_PREFIX + user.getId(), refreshToken, Duration.ofDays(refreshExpDays));
+
+        return new AuthVo(accessToken, refreshToken);
+    }
+
+    public AuthVo refreshAccessToken(RefreshTokenVo refreshVo) {
+        String savedToken = redisTemplate.opsForValue().get(REFRESH_PREFIX + refreshVo.userId());
+
+        if (savedToken == null) throw new ServiceException(ExceptionStatus.REFRESH_TOKEN_NOT_FOUND);
+        if (!savedToken.equals(refreshVo.refreshToken())) throw new ServiceException(ExceptionStatus.REFRESH_TOKEN_MISMATCH);
+        if (!jwtProvider.validateToken(refreshVo.refreshToken()) || !jwtProvider.isRefreshToken(refreshVo.refreshToken())) {
+            throw new ServiceException(ExceptionStatus.REFRESH_TOKEN_EXPIRED);
+        }
+
+        String email = jwtProvider.getEmail(refreshVo.refreshToken());
+        String name = jwtProvider.getName(refreshVo.refreshToken());
+        String role = jwtProvider.getRole(refreshVo.refreshToken());
+
+        String newAccessToken = jwtProvider.generateAccessToken(refreshVo.userId(), email, name, role);
+        return new AuthVo(newAccessToken, refreshVo.refreshToken());
+    }
+
+    public void logout(String userId) {
+        redisTemplate.delete(REFRESH_PREFIX + userId);
+    }
+}

--- a/user/src/main/java/com/ns/user/user/vo/AuthVo.java
+++ b/user/src/main/java/com/ns/user/user/vo/AuthVo.java
@@ -1,0 +1,4 @@
+package com.ns.user.user.vo;
+
+public record AuthVo(String accessToken, String refreshToken) {}
+

--- a/user/src/main/java/com/ns/user/user/vo/GoogleLoginVo.java
+++ b/user/src/main/java/com/ns/user/user/vo/GoogleLoginVo.java
@@ -1,0 +1,7 @@
+package com.ns.user.user.vo;
+
+public record GoogleLoginVo(String code) {
+    public static GoogleLoginVo of(String code){
+        return new GoogleLoginVo(code);
+    }
+}

--- a/user/src/main/java/com/ns/user/user/vo/RefreshTokenVo.java
+++ b/user/src/main/java/com/ns/user/user/vo/RefreshTokenVo.java
@@ -1,0 +1,8 @@
+package com.ns.user.user.vo;
+
+public record RefreshTokenVo(String userId, String refreshToken) {
+    public static RefreshTokenVo of(String userId, String refreshToken){
+        return new RefreshTokenVo(userId,refreshToken);
+    }
+}
+

--- a/user/src/test/java/com/ns/user/user/UserServiceTest.java
+++ b/user/src/test/java/com/ns/user/user/UserServiceTest.java
@@ -1,0 +1,161 @@
+package com.ns.user.user;
+
+import com.ns.user.exception.ExceptionStatus;
+import com.ns.user.exception.ServiceException;
+import com.ns.user.jwt.JwtTokenProvider;
+import com.ns.user.oauth.GoogleIdTokenVerifier;
+import com.ns.user.oauth.GoogleOAuthClient;
+import com.ns.user.user.entity.UserEntity;
+import com.ns.user.user.repository.UserRepository;
+import com.ns.user.user.service.UserService;
+import com.ns.user.user.vo.AuthVo;
+import com.ns.user.user.vo.GoogleLoginVo;
+import com.ns.user.user.vo.RefreshTokenVo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+
+class UserServiceTest {
+    @Mock
+    private GoogleOAuthClient googleOAuthClient;
+    @Mock private GoogleIdTokenVerifier googleIdTokenVerifier;
+    @Mock private UserRepository userRepository;
+    @Mock private JwtTokenProvider jwtTokenProvider;
+    @Mock private StringRedisTemplate redisTemplate;
+    @Mock private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private UserService userService;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    @DisplayName("구글 로그인 성공 시 새로운 유저 저장 + 토큰 발급")
+    void loginWithGoogle_success_newUser() {
+        // given
+        String code = "dummy-code";
+        GoogleLoginVo loginVo = GoogleLoginVo.of(code);
+
+        GoogleOAuthClient.GoogleTokenResponse mockResponse = new GoogleOAuthClient.GoogleTokenResponse(
+                "dummy-access-token", // access_token
+                "dummy-id-token",     // id_token
+                null,                 // refresh_token (테스트에선 null)
+                "openid email profile",
+                "Bearer",
+                3600L
+        );
+
+        when(googleOAuthClient.getTokens(code)).thenReturn(mockResponse);
+
+        when(googleIdTokenVerifier.verify("dummy-id-token"))
+                .thenReturn(new GoogleIdTokenVerifier.GoogleUserInfo("sub-123", "test@email.com", "tester"));
+
+        when(userRepository.findById("sub-123")).thenReturn(Optional.empty());
+        when(userRepository.save(any(UserEntity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        when(jwtTokenProvider.generateAccessToken(any(), any(), any(), any()))
+                .thenReturn("access.jwt.token");
+        when(jwtTokenProvider.generateRefreshToken(any()))
+                .thenReturn("refresh.jwt.token");
+
+        // when
+        AuthVo result = userService.loginWithGoogle(loginVo);
+
+        // then
+        assertThat(result.accessToken()).isEqualTo("access.jwt.token");
+        assertThat(result.refreshToken()).isEqualTo("refresh.jwt.token");
+
+        verify(userRepository, times(1)).save(any(UserEntity.class));
+        verify(valueOperations).set(startsWith("refresh:"), eq("refresh.jwt.token"), any());
+    }
+
+
+    @Test
+    @DisplayName("RefreshToken 유효 → AccessToken 재발급 성공")
+    void refreshAccessToken_success() {
+        // given
+        String userId = "sub-123";
+        String refreshToken = "refresh.jwt.token";
+        RefreshTokenVo refreshVo = RefreshTokenVo.of(userId, refreshToken);
+
+        when(redisTemplate.opsForValue().get("refresh:" + userId))
+                .thenReturn(refreshToken);
+        when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
+        when(jwtTokenProvider.isRefreshToken(refreshToken)).thenReturn(true);
+        when(jwtTokenProvider.getEmail(refreshToken)).thenReturn("test@email.com");
+        when(jwtTokenProvider.getName(refreshToken)).thenReturn("tester");
+        when(jwtTokenProvider.getRole(refreshToken)).thenReturn("USER");
+        when(jwtTokenProvider.generateAccessToken(userId, "test@email.com", "tester", "USER"))
+                .thenReturn("new.access.jwt");
+
+        // when
+        AuthVo result = userService.refreshAccessToken(refreshVo);
+
+        // then
+        assertThat(result.accessToken()).isEqualTo("new.access.jwt");
+        assertThat(result.refreshToken()).isNull();
+    }
+
+    @Test
+    @DisplayName("RefreshToken 불일치 → 예외 발생")
+    void refreshAccessToken_mismatch() {
+        // given
+        String userId = "sub-123";
+        RefreshTokenVo refreshVo = RefreshTokenVo.of(userId, "wrong-token");
+
+        when(redisTemplate.opsForValue().get("refresh:" + userId))
+                .thenReturn("other-token");
+
+        // when / then
+        assertThatThrownBy(() -> userService.refreshAccessToken(refreshVo))
+                .isInstanceOf(ServiceException.class)
+                .hasMessage(ExceptionStatus.REFRESH_TOKEN_MISMATCH.getMessage());
+    }
+
+    @Test
+    @DisplayName("Redis에 RefreshToken 없음 → 예외 발생")
+    void refreshAccessToken_notFound() {
+        // given
+        String userId = "sub-123";
+        RefreshTokenVo refreshVo = RefreshTokenVo.of(userId, "some-token");
+
+        when(redisTemplate.opsForValue().get("refresh:" + userId))
+                .thenReturn(null);
+
+        // when / then
+        assertThatThrownBy(() -> userService.refreshAccessToken(refreshVo))
+                .isInstanceOf(ServiceException.class)
+                .hasMessage(ExceptionStatus.REFRESH_TOKEN_NOT_FOUND.getMessage());
+    }
+
+
+    @Test
+    @DisplayName("로그아웃 시 Redis RefreshToken 삭제")
+    void logout_success() {
+        // given
+        String userId = "sub-123";
+
+        // when
+        userService.logout(userId);
+
+        // then
+        verify(redisTemplate, times(1)).delete("refresh:" + userId);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #4 

## 📝작업 내용

> 구글 SSO 프로젝트를 생성하여 발급 받은 토큰 값과 code 값을 바탕으로 jwt 를 발급하는 로직을 만들었습니다.

> 원래는 login 과 register이 있어야한다고 생각했지만 google SSO 를 사용하는 다른 사이트를 봤을때 
db를 보고 기존회원인 경우 jwt 발급 신규회원인경우 db save 후 바로 jwt 발급 이라서 따로 login logut 없이 프론트에서 리다이렉트로 건내주는 fallback api만 만들었습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 머지먼저 하지 마세요
